### PR TITLE
DomDocument

### DIFF
--- a/src/ArrayToXml.php
+++ b/src/ArrayToXml.php
@@ -2,45 +2,47 @@
 
 namespace Spatie\ArrayToXml;
 
-use SimpleXMLElement;
+use DOMDocument;
 
-class ArrayToXml
-{
+class ArrayToXml {
+
     /**
      * Convert the given array to an xml string
-     *
-     * @param $array
+     * 
+     * @param string[] $array
      * @param string $rootElementName
-     * @param null $xml
-     * @return string
+     * @return type
      */
-    public static function convert($array, $rootElementName = '', $xml = null)
-    {
-        if ($xml === null) {
-            $xml = new SimpleXMLElement(self::getRootElement($rootElementName));
-        }
-
+    public static function convert(array $array, $rootElementName = '') {
+        $DOMDocument = new DOMDocument();
+        $root = $DOMDocument->createElement($rootElementName == '' ? 'root' : $rootElementName);
         foreach ($array as $key => $value) {
-            $key = str_replace(' ', '_', $key);
-
-            if (is_array($value)) {
-                self::convert($value, $key, $xml->addChild($key));
-            } else {
-                $xml->addChild($key, $value);
-            }
+            $root->appendChild(self::convertElement($value, $key, $DOMDocument));
         }
 
-        return $xml->asXML();
+        $DOMDocument->appendChild($root);
+        return $DOMDocument->saveXML();
     }
 
     /**
-     * Get the root element for the given name
-     *
-     * @param $name
-     * @return string
+     * Parse individual element
+     * 
+     * @param string|string[] $value
+     * @param string $key
+     * @param \DOMDocument $DOMDocument
+     * @return \DOMElement
      */
-    private static function getRootElement($name)
-    {
-        return '<'.($name == '' ? 'root' : $name).'/>';
+    private static function convertElement($value, $key, DOMDocument $DOMDocument) {
+        $key = str_replace(' ', '_', $key);
+        $element = $DOMDocument->createElement($key);
+        if (is_array($value)) {
+            foreach ($value as $key => $value) {
+                $element->appendChild(self::convertElement($value, $key, $DOMDocument));
+            }
+        } else {
+            $element->nodeValue = $value;
+        }
+        return $element;
     }
+
 }


### PR DESCRIPTION
Using DOMDocument::createElement() will check if the array key name is valid as an xml tagname. If it's not (like with numeric keys) a DOMException with DOM_INVALID_CHARACTER_ERR will be raised.

One thing that should be considered is that spaces in a tagname are automatically converted to '_' at the moment, but would normally also result in the exception. So there are 2 paths to consider:

1. try and fix the tagname automatically. Downside here is that when the xml is parsed back to an array, some keys might be different, with no way to tell which.
2. let DOMDocument parse the tagname and raise an exception if necessary. 